### PR TITLE
Auth 인증방식 수정 & Cancel API 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Iamport.payments(status: "paid")
 Iamport.payments(status: "paid", page: 2)
 ```
 
+## cancel API
+body의 값은 [API 문서 - cancel](https://api.iamport.kr/#!/payments/cancelPayment)에 있는 사용하는 것을 추가하여 진행하면 됩니다.​
+```
+body = {
+  imp_uid: "IMP_UID",
+  merchant_uid: "M00001",
+  amount: ""
+}
+Iamport.cancel(body)
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ body = {
 Iamport.cancel(body)
 ```
 
+## find API
+가맹점지정 고유번호를 이용하여 결제정보를 찾는 API
+
+```
+Iamport.find("M00001")
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/iamport.rb
+++ b/lib/iamport.rb
@@ -52,6 +52,15 @@ module Iamport
       result
     end
 
+    # Find payment information using merchant uid
+    # https://api.iamport.kr/#!/payments/getPaymentByMerchantUid
+    def find(merchant_uid)
+      uri = "payments/find/#{merchant_uid}"
+
+      result = pay_get(uri)
+      result
+    end
+
     # Canceled payments
     # https://api.iamport.kr/#!/payments/cancelPayment
     def cancel(body)

--- a/lib/iamport.rb
+++ b/lib/iamport.rb
@@ -35,8 +35,7 @@ module Iamport
     def payment(imp_uid)
       uri = "payments/#{imp_uid}"
 
-      result = pay_get(uri)
-      result
+      pay_get(uri)
     end
 
     # Search payment information using status.
@@ -48,8 +47,7 @@ module Iamport
 
       uri = "payments/status/#{status}?page=#{page}"
 
-      result = pay_get(uri)
-      result
+      pay_get(uri)
     end
 
     # Find payment information using merchant uid
@@ -57,8 +55,7 @@ module Iamport
     def find(merchant_uid)
       uri = "payments/find/#{merchant_uid}"
 
-      result = pay_get(uri)
-      result
+      pay_get(uri)
     end
 
     # Canceled payments
@@ -66,31 +63,28 @@ module Iamport
     def cancel(body)
       uri = "payments/cancel"
 
-      result = pay_post(uri, body)
-      result
+      pay_post(uri, body)
     end
 
     private
 
     # Get header data
     def get_headers
-      { Authorization: token }
+      { "Authorization" => token }
     end
 
     # GET
     def pay_get(uri, payload = {})
       url = "#{IAMPORT_HOST}/#{uri}"
 
-      response = HTTParty.get url, headers: get_headers, body: payload
-      response["response"]
+      HTTParty.get url, headers: get_headers, body: payload
     end
 
     # POST
     def pay_post(uri, payload = {})
       url = "#{IAMPORT_HOST}/#{uri}"
 
-      response = HTTParty.post url, headers: get_headers, body: payload
-      response["response"]
+      HTTParty.post url, headers: get_headers, body: payload
     end
   end
 end

--- a/lib/iamport.rb
+++ b/lib/iamport.rb
@@ -52,6 +52,15 @@ module Iamport
       result
     end
 
+    # Canceled payments
+    # https://api.iamport.kr/#!/payments/cancelPayment
+    def cancel(body)
+      uri = "payments/cancel"
+
+      result = pay_post(uri, body)
+      result
+    end
+
     private
 
     # Get header data

--- a/lib/iamport.rb
+++ b/lib/iamport.rb
@@ -1,7 +1,7 @@
 require "iamport/version"
 
 module Iamport
-  IAMPORT_HOST = "api.iamport.kr:443"
+  IAMPORT_HOST = "https://api.iamport.kr"
 
   class Config
     attr_accessor :api_key
@@ -17,25 +17,62 @@ module Iamport
       @config ||= Config.new
     end
 
+    # Get Token
+    # https://api.iamport.kr/#!/authenticate/getToken
     def token
-      url = "https://#{IAMPORT_HOST}/users/getToken"
-      result = HTTParty.post url, body: { imp_key: config.api_key, imp_secret: config.api_secret }
+      url = "#{IAMPORT_HOST}/users/getToken"
+      body = {
+          imp_key: config.api_key,
+          imp_secret: config.api_secret
+      }
+
+      result = HTTParty.post url, body: body
       result["response"]["access_token"]
     end
 
+    # Get payment information using imp_uid
+    # https://api.iamport.kr/#!/payments/getPaymentByImpUid
     def payment(imp_uid)
-      url = "https://#{IAMPORT_HOST}/payments/#{imp_uid}?_token=#{token}"
-      result = HTTParty.post url
-      result["response"]
+      uri = "payments/#{imp_uid}"
+
+      result = pay_get(uri)
+      result
     end
 
+    # Search payment information using status.
+    # default items per page: 20
+    # https://api.iamport.kr/#!/payments/getPaymentsByStatus
     def payments(options = {})
       status = options[:status] || "all"
       page = options[:page] || 1
 
-      url = "https://#{IAMPORT_HOST}/payments/status/#{status}?_token=#{token}&page=#{page}"
-      result = HTTParty.post url
-      result["response"]
+      uri = "payments/status/#{status}?page=#{page}"
+
+      result = pay_get(uri)
+      result
+    end
+
+    private
+
+    # Get header data
+    def get_headers
+      { Authorization: token }
+    end
+
+    # GET
+    def pay_get(uri, payload = {})
+      url = "#{IAMPORT_HOST}/#{uri}"
+
+      response = HTTParty.get url, headers: get_headers, body: payload
+      response["response"]
+    end
+
+    # POST
+    def pay_post(uri, payload = {})
+      url = "#{IAMPORT_HOST}/#{uri}"
+
+      response = HTTParty.post url, headers: get_headers, body: payload
+      response["response"]
     end
   end
 end

--- a/lib/iamport/version.rb
+++ b/lib/iamport/version.rb
@@ -1,3 +1,3 @@
 module Iamport
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/lib/iamport/version.rb
+++ b/lib/iamport/version.rb
@@ -1,3 +1,3 @@
 module Iamport
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/lib/iamport/version.rb
+++ b/lib/iamport/version.rb
@@ -1,3 +1,3 @@
 module Iamport
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/iamport_spec.rb
+++ b/spec/iamport_spec.rb
@@ -91,7 +91,7 @@ describe Iamport do
       expected_url = "#{IAMPORT_HOST}/payments/IMP_UID"
       expected_params = {
           headers: {
-              Authorization: "NEW_TOKEN"
+              "Authorization" => "NEW_TOKEN"
           },
           body: {}
       }
@@ -114,7 +114,7 @@ describe Iamport do
       expected_url = "#{IAMPORT_HOST}/payments/status/all?page=1"
       expected_params = {
           headers: {
-              Authorization: "NEW_TOKEN"
+              "Authorization" => "NEW_TOKEN"
           },
           body: {}
       }
@@ -146,7 +146,7 @@ describe Iamport do
       expected_url = "#{IAMPORT_HOST}/payments/cancel"
       expected_params = {
           headers: {
-              Authorization: "NEW_TOKEN"
+              "Authorization" => "NEW_TOKEN"
           },
           body: {
               imp_uid: "IMP_UID",
@@ -180,7 +180,7 @@ describe Iamport do
       expected_url = "#{IAMPORT_HOST}/payments/find/M00001"
       expected_params = {
         headers: {
-          Authorization: "NEW_TOKEN"
+          "Authorization" => "NEW_TOKEN"
         },
         body: {}
       }

--- a/spec/iamport_spec.rb
+++ b/spec/iamport_spec.rb
@@ -172,5 +172,29 @@ describe Iamport do
       expect(res["merchant_uid"]).to eq("M00001")
     end
   end
+
+  describe 'find' do
+    it 'return pyments using merchant_uid' do
+      allow(Iamport).to receive(:token).and_return 'NEW_TOKEN'
+
+      expected_url = "#{IAMPORT_HOST}/payments/find/M00001"
+      expected_params = {
+        headers: {
+          Authorization: "NEW_TOKEN"
+        },
+        body: {}
+      }
+
+      response = {
+          "response" => payment_json
+      }
+
+      expect(HTTParty).to receive(:get).with(expected_url, expected_params).and_return(response)
+
+      res = Iamport.find("M00001")
+      expect(res["merchant_uid"]).to eq("M00001")
+      expect(res["imp_uid"]).to eq("IMP_UID")
+    end
+  end
 end
 

--- a/spec/iamport_spec.rb
+++ b/spec/iamport_spec.rb
@@ -138,5 +138,39 @@ describe Iamport do
       expect(res["list"].size).to eq(2)
     end
   end
+
+  describe 'cancel' do
+    it 'return cancel info' do
+      allow(Iamport).to receive(:token).and_return 'NEW_TOKEN'
+
+      expected_url = "#{IAMPORT_HOST}/payments/cancel"
+      expected_params = {
+          headers: {
+              Authorization: "NEW_TOKEN"
+          },
+          body: {
+              imp_uid: "IMP_UID",
+              merchant_uid: "M00001"
+          }
+      }
+
+      response = {
+          "code" => 0,
+          "message" => '',
+          "response" => {
+              "imp_uid" => "IMP_UID",
+              "merchant_uid" => "M00001"
+          }
+      }
+
+      expect(HTTParty).to receive(:post).with(expected_url, expected_params).and_return(response)
+
+      body = expected_params[:body]
+
+      res = Iamport.cancel(body)
+      expect(res["imp_uid"]).to eq("IMP_UID")
+      expect(res["merchant_uid"]).to eq("M00001")
+    end
+  end
 end
 

--- a/spec/iamport_spec.rb
+++ b/spec/iamport_spec.rb
@@ -13,12 +13,14 @@ describe Iamport, ".configure" do
       config.api_key = "API_KEY"
       config.api_secret = "API_SECRET"
     end
-    expect(Iamport.config.api_key).to eq "API_KEY"
-    expect(Iamport.config.api_secret).to eq "API_SECRET"
+    expect(Iamport.config.api_key).to eq("API_KEY")
+    expect(Iamport.config.api_secret).to eq("API_SECRET")
   end
 end
 
 describe Iamport do
+  IAMPORT_HOST = "https://api.iamport.kr"
+
   before do
     Iamport.configure do |config|
       config.api_key = "API_KEY"
@@ -28,18 +30,20 @@ describe Iamport do
 
   describe ".token" do
     it "generates and returns new token" do
-      expected_url = "https://api.iamport.kr:443/users/getToken"
+      expected_url = "#{IAMPORT_HOST}/users/getToken"
       expected_params = {
         body: {
          imp_key: "API_KEY",
          imp_secret: "API_SECRET",
         }
       }
+
       response = {
         "response" => {
           "access_token" => "NEW_TOKEN"
         }
       }
+
       expect(HTTParty).to receive(:post).with(expected_url, expected_params).and_return(response)
 
       expect(Iamport.token).to eq("NEW_TOKEN")
@@ -84,20 +88,37 @@ describe Iamport do
     it "returns payment info" do
       allow(Iamport).to receive(:token).and_return("NEW_TOKEN")
 
-      expected_url = "https://api.iamport.kr:443/payments/IMP_UID?_token=NEW_TOKEN"
+      expected_url = "#{IAMPORT_HOST}/payments/IMP_UID"
+      expected_params = {
+          headers: {
+              Authorization: "NEW_TOKEN"
+          },
+          body: {}
+      }
+
       response = {
         "response" => payment_json,
       }
-      expect(HTTParty).to receive(:post).with(expected_url).and_return(response)
+
+      expect(HTTParty).to receive(:get).with(expected_url, expected_params).and_return(response)
 
       res = Iamport.payment("IMP_UID")
       expect(res["imp_uid"]).to eq("IMP_UID")
     end
   end
+
   describe "payments" do
     it "returns payment list" do
       allow(Iamport).to receive(:token).and_return("NEW_TOKEN")
-      expected_url = "https://api.iamport.kr:443/payments/status/all?_token=NEW_TOKEN&page=1"
+
+      expected_url = "#{IAMPORT_HOST}/payments/status/all?page=1"
+      expected_params = {
+          headers: {
+              Authorization: "NEW_TOKEN"
+          },
+          body: {}
+      }
+
       response = {
         "response" => {
           "total" => 150,
@@ -109,7 +130,8 @@ describe Iamport do
           ]
         }
       }
-      expect(HTTParty).to receive(:post).with(expected_url).and_return(response)
+
+      expect(HTTParty).to receive(:get).with(expected_url, expected_params).and_return(response)
 
       res = Iamport.payments
       expect(res["total"]).to eq(150)


### PR DESCRIPTION
- Auth 인증을 URI에 넣어 하던 방식에서 Header로 옮겨서 넘겨주도록 수정하였습니다.
- Cancel API 추가하였습니다.
- issue: #2, #3 
