### PR TITLE
httparty를 faraday로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea/

--- a/iamport.gemspec
+++ b/iamport.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 
-  spec.add_runtime_dependency "httparty"
+  spec.add_runtime_dependency "faraday"
 end

--- a/lib/iamport.rb
+++ b/lib/iamport.rb
@@ -1,7 +1,7 @@
 require "iamport/version"
 
 module Iamport
-  IAMPORT_HOST = "https://api.iamport.kr"
+  IAMPORT_HOST = "https://api.iamport.kr".freeze
 
   class Config
     attr_accessor :api_key
@@ -26,7 +26,7 @@ module Iamport
           imp_secret: config.api_secret
       }
 
-      result = HTTParty.post url, body: body
+      result = Faraday.post url, body: body
       result["response"]["access_token"]
     end
 
@@ -77,14 +77,14 @@ module Iamport
     def pay_get(uri, payload = {})
       url = "#{IAMPORT_HOST}/#{uri}"
 
-      HTTParty.get url, headers: get_headers, body: payload
+      Faraday.get(url, headers: get_headers, body: payload)['response']
     end
 
     # POST
     def pay_post(uri, payload = {})
       url = "#{IAMPORT_HOST}/#{uri}"
 
-      HTTParty.post url, headers: get_headers, body: payload
+      Faraday.post(url, headers: get_headers, body: payload)['response']
     end
   end
 end

--- a/spec/iamport_spec.rb
+++ b/spec/iamport_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'httparty'
+require 'faraday'
 
 describe Iamport, "::VERSION" do
   it 'has a version number' do
@@ -44,7 +44,7 @@ describe Iamport do
         }
       }
 
-      expect(HTTParty).to receive(:post).with(expected_url, expected_params).and_return(response)
+      expect(Faraday).to receive(:post).with(expected_url, expected_params).and_return(response)
 
       expect(Iamport.token).to eq("NEW_TOKEN")
     end
@@ -100,7 +100,7 @@ describe Iamport do
         "response" => payment_json,
       }
 
-      expect(HTTParty).to receive(:get).with(expected_url, expected_params).and_return(response)
+      expect(Faraday).to receive(:get).with(expected_url, expected_params).and_return(response)
 
       res = Iamport.payment("IMP_UID")
       expect(res["imp_uid"]).to eq("IMP_UID")
@@ -131,7 +131,7 @@ describe Iamport do
         }
       }
 
-      expect(HTTParty).to receive(:get).with(expected_url, expected_params).and_return(response)
+      expect(Faraday).to receive(:get).with(expected_url, expected_params).and_return(response)
 
       res = Iamport.payments
       expect(res["total"]).to eq(150)
@@ -163,7 +163,7 @@ describe Iamport do
           }
       }
 
-      expect(HTTParty).to receive(:post).with(expected_url, expected_params).and_return(response)
+      expect(Faraday).to receive(:post).with(expected_url, expected_params).and_return(response)
 
       body = expected_params[:body]
 
@@ -189,7 +189,7 @@ describe Iamport do
           "response" => payment_json
       }
 
-      expect(HTTParty).to receive(:get).with(expected_url, expected_params).and_return(response)
+      expect(Faraday).to receive(:get).with(expected_url, expected_params).and_return(response)
 
       res = Iamport.find("M00001")
       expect(res["merchant_uid"]).to eq("M00001")
@@ -197,4 +197,3 @@ describe Iamport do
     end
   end
 end
-


### PR DESCRIPTION
* httparty 젬은 16년 이후로 업데이트가 없어서 유지보수가 계속되고 있는 faraday 로 변경
* Iamport::IAMPORT_HOST 상수를 freeze 시킴
* spec 이 깨지지 않도록 pay_post와 pay_get 가 response를 리턴하도록 변경